### PR TITLE
Move the screenshot step to a place where it makes more sense

### DIFF
--- a/KITE-Licode-Test/js/LicodeTest.js
+++ b/KITE-Licode-Test/js/LicodeTest.js
@@ -18,14 +18,14 @@ class LicodeTest extends KiteBaseTest {
       let openUrlStep = new OpenUrlStep(this);
       await openUrlStep.execute(this);
 
-      let screenshotStep = new ScreenshotStep(this);
-      await screenshotStep.execute(this);
-
       let publishedVideoCheck = new PublishedVideoCheck(this);
       await publishedVideoCheck.execute(this);
 
       let subscribedVideoCheck = new SubscribedVideoCheck(this);
       await subscribedVideoCheck.execute(this);
+      
+      let screenshotStep = new ScreenshotStep(this);
+      await screenshotStep.execute(this);
 
       if (this.getStats) {
         let getStatsStep = new GetStatsStep(this);


### PR DESCRIPTION
`ScreenshotStep` would often capture empty videos. This PR fixes that